### PR TITLE
Don't try to use 32BLIT_DIR until we've found it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@
 cmake_minimum_required(VERSION 3.9)
 
 # Wrapper for the Pico SDK, which is only included if PICO_BOARD is set
-include(${32BLIT_DIR}/32blit-pico/sdk_import.cmake)
+if (PICO_BOARD)
+    include(${32BLIT_DIR}/32blit-pico/sdk_import.cmake)
+endif()
 
 project(snake)
 


### PR DESCRIPTION
This variable is set by find_package after it has found the SDK so
attempting to use it before then won't work in all cases.